### PR TITLE
prevent non-existent task deletion

### DIFF
--- a/lib/slack/slack.ex
+++ b/lib/slack/slack.ex
@@ -100,8 +100,12 @@ defmodule Tasker.SlackBot do
           [""] ->
             send_message("<@#{message.user}> I don't know which task to delete!", message.channel, slack)
           [task_name] ->
-            remove_task(task_name)
-            |> send_task_remove_success_message(message, slack)
+            if(find_task(task_name)) do
+              remove_task(task_name)
+              |> send_task_remove_success_message(message, slack)
+            else
+              send_message("<@#{message.user}> I didn't find that task to delete!", message.channel, slack)
+            end
         end
 
       Regex.match?(@regexp_rename_task, command) ->

--- a/lib/slack/tasker_helper.ex
+++ b/lib/slack/tasker_helper.ex
@@ -66,6 +66,10 @@ defmodule Tasker.TaskerHelper do
       task_name
     end
 
+    def find_task(task_name) do
+      find_task(task_name, :find)
+    end
+
   # Groups
     def create_users_group(users_map, group_name) when is_map(users_map) do
       case Enum.any?(get_cached_groups(), fn(cached_group) -> cached_group.name == group_name end) do
@@ -115,6 +119,10 @@ defmodule Tasker.TaskerHelper do
 
   defp updated_tasks(task_name, :remove) do
     Enum.reject(get_cached_tasks(), fn(cached_task) -> cached_task.name == task_name end)
+  end
+
+  defp find_task(task_name, :find) do
+    Enum.find(get_cached_tasks, fn(x) -> x.name == task_name end)
   end
 
   defp updated_tasks({task_name, task_new_name}, :rename) do


### PR DESCRIPTION
Currently we can keep deleting non-existent tasks in Cache. This PR prevents such deletion operations.